### PR TITLE
Typo fix and added "about opened modules" to the path to enlightenment

### DIFF
--- a/FSharpKoans/AboutOptionTypes.fs
+++ b/FSharpKoans/AboutOptionTypes.fs
@@ -26,7 +26,7 @@ type ``about option types``() =
         AssertThrows<FILL_IN_THE_EXCEPTION> (fun () -> noValue.Value)
 
     [<Koan>]
-    member this.UsingOptionTypesWithPatternPatching() =
+    member this.UsingOptionTypesWithPatternMatching() =
         let chronoTrigger = { Name = "Chrono Trigger"; Platform = "SNES"; Score = Some 5 }
         let gta = { Name = "Halo"; Platform = "Xbox"; Score = None }
 

--- a/FSharpKoans/PathToEnlightenment.fs
+++ b/FSharpKoans/PathToEnlightenment.fs
@@ -19,6 +19,7 @@ let (containers: obj list) = [ ``about asserts``();
                                ``about option types``();
                                ``about descriminated unions``();
                                ``about modules``();
+                               ``about opened modules``();
                                ``about classes``();
                                ]
 let runner = KoanRunner(containers)


### PR DESCRIPTION
Fixed typo PatternPatching -> PatternMatching
Added "about opened modules" to path to enlightenment
