### PR TITLE
Changed the order of a couple Koans and ensured the "open modules" koan runs

### DIFF
--- a/FSharpKoans/AboutClasses.fs
+++ b/FSharpKoans/AboutClasses.fs
@@ -36,7 +36,7 @@ type Person2(name:string) =
     member this.Speak() =
         "Hi my name is " + this.Name
 
-[<Koan(Sort = 20)>]
+[<Koan(Sort = 22)>]
 module ``about classes`` =
 
     [<Koan>]

--- a/FSharpKoans/AboutDotNetCollections.fs
+++ b/FSharpKoans/AboutDotNetCollections.fs
@@ -9,7 +9,7 @@ open System.Collections.Generic
 // languages, you can use all of the basic .NET collections types
 // you're already familiar with if you're a C# or VB programmer.
 //---------------------------------------------------------------
-[<Koan(Sort = 12)>]
+[<Koan(Sort = 14)>]
 module ``about dot net collections`` =
 
     [<Koan>]

--- a/FSharpKoans/AboutLooping.fs
+++ b/FSharpKoans/AboutLooping.fs
@@ -9,7 +9,7 @@ open FSharpKoans.Core
 // back on traditional imperative looping techniques that you may 
 // be more familiar with.
 //---------------------------------------------------------------
-[<Koan(Sort = 13)>]
+[<Koan(Sort = 12)>]
 module ``about looping`` =
     [<Koan>]
     let LoopingOverAList() =

--- a/FSharpKoans/AboutModules.fs
+++ b/FSharpKoans/AboutModules.fs
@@ -49,7 +49,8 @@ module ``about modules`` =
 
 open MushroomKingdom
 
-type ``about opened modules``() =
+[<Koan(Sort = 20)>]
+module ``about opened modules`` =
     [<Koan>]
     let OpenedModulesBringTheirContentsInScope() = 
         AssertEquality Mario.Name __

--- a/FSharpKoans/MoreAboutFunctions.fs
+++ b/FSharpKoans/MoreAboutFunctions.fs
@@ -8,7 +8,7 @@ open FSharpKoans.Core
 // since F# is a functional language, there are more tricks
 // to learn!
 //---------------------------------------------------------------
-[<Koan(Sort = 14)>]
+[<Koan(Sort = 13)>]
 module ``more about functions`` =
     
     [<Koan>]


### PR DESCRIPTION
I reordered the koans so that the "more about functions" module runs before the "about dot net collections" module so that lambdas are presented first. (fixes issue #14)

I also edited the "about open modules" attributes so that it runs along with the rest of the Koans (fixes issue #13)
