### PR TITLE
Wrapping Tuples to correct .ToString() issue.

### DIFF
--- a/FSharpKoans.Core/Helpers.fs
+++ b/FSharpKoans.Core/Helpers.fs
@@ -12,11 +12,30 @@ type FILL_ME_IN =
 type FILL_IN_THE_EXCEPTION() =
     inherit Exception()
 
+type TupleWrapper(innerTuple) =
+    member this.InnerTuple = innerTuple
+    override this.ToString() = sprintf "%A" innerTuple
+    override this.Equals that =
+        match that with
+        | :? TupleWrapper -> this.InnerTuple = (that :?> TupleWrapper).InnerTuple
+        | _ -> false
+
+let prepareAssertParam (param:obj) =
+    if param <> null && FSharpType.IsTuple (param.GetType()) then
+        new TupleWrapper(param) :> obj
+    else 
+        param
+
+let AssertEquality (x:'a) (y:'b) = 
+    Assert.AreEqual( prepareAssertParam x, 
+                     prepareAssertParam y)   
+
+let AssertInequality (x:'a) (y:'b) = 
+    Assert.AreNotEqual( prepareAssertParam x,
+                        prepareAssertParam y)
+
 let AssertWithMessage x message = Assert.IsTrue(x, message)
 
-let AssertEquality (x:'a) (y:'b) = Assert.AreEqual(x,y)   
-
-let AssertInequality (x:'a) (y:'b) = Assert.AreNotEqual(x,y)
 
 let AssertThrows<'a when 'a :> exn> action = Assert.Throws<'a>(fun () -> action())
 


### PR DESCRIPTION
This resolves an issue with the AboutTuples TheTruthBehindMultipleReturnValues Koan

NUnit's Assert.AreEqual() method was displaying a this (9.0, 27.0) as (9, 27).  This fix introduces an intermediate object that overrides ToString() using sprintf
