### PR TITLE
Instructions to run the Koans via command line under Mono

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -17,12 +17,11 @@ you to solve more complicated problems and use more advanced techniques.
 ### Getting Started
 
 The F# Koans currently target Visual Studio 2010. The koans
-should also work with Visual Studio 2008, Visual Studio 11, comand line Mono, and monodevelop.
-Instructions for those configurations are still //TODO for the time being.
+should also work with Visual Studio 2008, Visual Studio 11+, command line Mono, MonoDevelop, and Xamarin Studio.
 
-*NOTE: nuget (http://nuget.codeplex.com/) is required to properly resolve dependencies.*
+*NOTE: [NuGet](http://nuget.org/) is required to properly resolve dependencies.*
 
-### Running the Koans
+### Running the Koans in Visual Studio
 
 1. Open the Visual Studio project, right click on the "FSharpKoans" project in the solution explorer 
    and select "Set as StartUp Project".
@@ -31,3 +30,26 @@ Instructions for those configurations are still //TODO for the time being.
    from the Common Language Runtime Exceptions item.
 
 You can now run the Koans by selecting Debug|Start Debugging (defaults to f5).
+
+### Running the Koans from the command line (Mono)
+
+The following instructions will run the Koans without the need for Visual Studio, MonoDevelop, etc. 
+The only requirements are [Mono](http://www.mono-project.com/download/), [FSharp](http://fsharp.org), and [NuGet](http://nuget.org/nuget.exe).
+
+1. In a terminal, navigate to the root of the __FSharpKoans__ solution directory.
+
+2. Restore all NuGet packages (replace _/Path/To/NuGet_ with the appropriate directory for your 
+   environment): 
+   ```
+   mono /Path/To/NuGet/nuget.exe restore FSharpKoans.sln
+   ```
+ 
+3. Build the solution: 
+   ```
+   xbuild FSharpKoans.sln
+   ```
+
+You can now run the Koans (the following assumes your output path is _bin/Debug_): 
+```
+mono FSharpKoans/bin/Debug/FSharpKoans.exe
+```


### PR DESCRIPTION
The instructions are mainly for Mac/Linux users who wish to run the Koans purely from the command line. I also updated some other parts of the README for consistency with the new section.
