### PR TITLE
Add hint to parse numbers in decimal comma culture

### DIFF
--- a/FSharpKoans/AboutTheStockExample.fs
+++ b/FSharpKoans/AboutTheStockExample.fs
@@ -16,6 +16,9 @@ open FSharpKoans.Core
 // System.Double.Parse - converts a string argument into a 
 //                       numerical value.
 //
+// Hint: Use CultureInfo.InvariantCulture to always parse '.' as 
+// the decimal point.
+//
 // The following function will convert a comma separated string
 // into an array of the column values.
 //                       


### PR DESCRIPTION
In cultures with a decimal comma, System.Double.Parse will by default not be able to parse the stock data as floating numbers. Add a hint as to how to achieve this.
