### PR TITLE
Remove Prompt for Capturing a Mutable Variable in Closure

### DIFF
--- a/FSharpKoans/AboutFunctions.fs
+++ b/FSharpKoans/AboutFunctions.fs
@@ -70,5 +70,3 @@ module ``about functions`` =
                  
                  See http://en.wikipedia.org/wiki/Closure_(computer_science) 
                  for more about about closure. *)
-
-        (* TRY IT: What happens if you make suffix into a mutable variable? *)


### PR DESCRIPTION
Fix issue #41 by removing the prompt to try creating a mutable variable inside of a closure as this no longer produces an error in F# 4.0.
