### PR TITLE
yelled.Trim() will only remove spaces before text

### DIFF
--- a/FSharpKoans/AboutFunctions.fs
+++ b/FSharpKoans/AboutFunctions.fs
@@ -57,9 +57,9 @@ module ``about functions`` =
         let suffix = "!!!"
 
         let caffeinate (text:string) =
-            let exclaimed = text + suffix
+            let exclaimed = text.Trim() + suffix
             let yelled = exclaimed.ToUpper()
-            yelled.Trim()
+            yelled
 
         let caffeinatedReply = caffeinate "hello there"
 


### PR DESCRIPTION
Spaces after text would still be preserved in the original version. Since there should not be spaces before "!!!" in the output and there should not be spaces before a statement as per the previous version, this change should fix the issue.
