### PR TITLE
fix equality to require identical types

### DIFF
--- a/FSharpKoans.Core/Helpers.fs
+++ b/FSharpKoans.Core/Helpers.fs
@@ -4,7 +4,7 @@ module FSharpKoans.Core.Helpers
 open System
 open NUnit.Framework
 
-let __ = "FILL ME IN"
+let __<'T> : 'T = failwith "Seek wisdom by filling in the __"
 
 type FILL_ME_IN =
     class end
@@ -14,9 +14,9 @@ type FILL_IN_THE_EXCEPTION() =
 
 let AssertWithMessage x message = Assert.IsTrue(x, message)
 
-let AssertEquality (x:'a) (y:'b) = Assert.AreEqual(x,y)   
+let AssertEquality (x:'T) (y:'T) = Assert.AreEqual(x,y)   
 
-let AssertInequality (x:'a) (y:'b) = Assert.AreNotEqual(x,y)
+let AssertInequality (x:'T) (y:'T) = Assert.AreNotEqual(x,y)
 
 let AssertThrows<'a when 'a :> exn> action = Assert.Throws<'a>(fun () -> action())
 

--- a/FSharpKoans.Core/Helpers.fs
+++ b/FSharpKoans.Core/Helpers.fs
@@ -4,7 +4,7 @@ module FSharpKoans.Core.Helpers
 open System
 open NUnit.Framework
 
-let __<'T> : 'T = failwith "Seek wisdom by filling in the __"
+let inline __<'T> : 'T = failwith "Seek wisdom by filling in the __"
 
 type FILL_ME_IN =
     class end

--- a/FSharpKoans/AboutUnit.fs
+++ b/FSharpKoans/AboutUnit.fs
@@ -19,7 +19,7 @@ module ``about unit`` =
             ()
 
         let x = sendData "data"
-        AssertEquality x __ //Don't overthink this
+        AssertEquality x __ //Don't overthink this. Note also the value "()" displays as "null" in some cases.
 
     [<Koan>]
     let ParameterlessFunctionsTakeUnitAsTheirArgument() =

--- a/FSharpKoans/FSharpKoans.fsproj
+++ b/FSharpKoans/FSharpKoans.fsproj
@@ -16,6 +16,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION

@ChrisMarinos Here is a fix for https://github.com/ChrisMarinos/FSharpKoans/issues/15 if you agree

Basically it checks that the types are correct in the equality before allowing you to run. What do you think?

thanks