### PR TITLE
Utilize inequality operator (<>); Remove 'not'

### DIFF
--- a/FSharpKoans/AboutLists.fs
+++ b/FSharpKoans/AboutLists.fs
@@ -114,7 +114,7 @@ module ``about lists`` =
     [<Koan>]
     let DividingListsWithPartition() =
         let isOdd x =
-            not(x % 2 = 0)
+            x % 2 <> 0
 
         let original = [0..5]
         let result1, result2 = List.partition isOdd original


### PR DESCRIPTION
It would be nice to provide an example of the inequality operator, even if we don't say anything about it explicitly. From a pedagogical perspective, the user will still compare `isOdd` to `isEven`, which is just above, and quickly understand the difference. However, the inequality operator seems like the more lightweight, elegant solution since `not` requires parentheses in this case.

`not` might be natural to introduce in the "About Pipelining" section, if you still think it's necessary. I'd be willing to help with that if you do.

Go Blue!