### PR TITLE
Change 'variance' to 'difference'; pluralize 'price'

### DIFF
--- a/FSharpKoans/AboutTheStockExample.fs
+++ b/FSharpKoans/AboutTheStockExample.fs
@@ -7,7 +7,7 @@ open FSharpKoans.Core
 // Below is a list containing comma separated data about 
 // Microsoft's stock prices during March of 2012. Without
 // modifying the list, programatically find the day with the
-// greatest variance between the opening and closing price.
+// greatest difference between the opening and closing prices.
 //
 // The following functions may be of use:
 // 


### PR DESCRIPTION
I was confused for a good 5-10 minutes about the use of the word "variance" in the stock example. With my limited knowledge of statistics, I thought the question might be referring to statistical variance. I started looking up the formula for variance, which made me more confused. However, I soon realized that the question must be referring to the "difference" between values. I made this change to prevent any further confusion.

Since it's in the same line, I pluralized the word "price." Opening and closing prices are two distinct values.