### PR TITLE
Remove Dotnet Watcher

### DIFF
--- a/FSharpKoans/FSharpKoans.fsproj
+++ b/FSharpKoans/FSharpKoans.fsproj
@@ -31,7 +31,4 @@
   <ItemGroup>
     <ProjectReference Include="..\FSharpKoans.Core\FSharpKoans.Core.fsproj" />
   </ItemGroup>
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="2.0.0" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
Resolves warning: 
`/usr/local/share/dotnet/sdk/2.1.302/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.ObsoleteReferences.targets(33,5): warning : The tool 'Microsoft.DotNet.Watcher.Tools' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).`

Watch is now built-in to .net sdk, so it can be removed.