### PR TITLE
Added an extra information about creating a sequence of type int

### DIFF
--- a/FSharpKoans/AboutDotNetCollections.fs
+++ b/FSharpKoans/AboutDotNetCollections.fs
@@ -47,7 +47,7 @@ module ``about dot net collections`` =
         //NOTE: The seq type in F# is an alias for .NET's IEnumerable interface
         //      Like the List and Array module, the Seq module contains functions 
         //      that you can combine to perform operations on types implementing 
-        //      seq/IEnumerable.
+        //      seq/IEnumerable. To create a new sequence you can use seq<int>{0 .. 10}.
 
         AssertEquality verboseBook.[0] __
         AssertEquality verboseBook.[1] __


### PR DESCRIPTION
I felt that some extra information was missing since the Seq.skip will cast List<int> to seq<int> type.