### PR TITLE
Return a more consistent error message for type assertions.

### DIFF
--- a/FSharpKoans.Core/Helpers.fs
+++ b/FSharpKoans.Core/Helpers.fs
@@ -14,7 +14,11 @@ type FILL_IN_THE_EXCEPTION() =
 
 let AssertWithMessage (x : bool) message = Assert.IsTrue(x, message)
 
-let AssertEquality (x:'T) (y:'T) = Assert.AreEqual(x,y)
+let inline AssertEquality (x:'T) (y:'T) =
+    match box y with
+    | :? System.Type as t when t = typeof<FILL_ME_IN> -> failwith "Seek wisdom by correcting the type FILL_ME_IN"
+    | :? System.Type as t when t = typeof<FILL_IN_THE_EXCEPTION> -> failwith "Seek wisdom by correcting the type FILL_IN_THE_EXCEPTION"
+    | _ -> Assert.AreEqual(x,y)
 
 let AssertInequality (x:'T) (y:'T) = Assert.AreNotEqual(x,y)
 


### PR DESCRIPTION
Regarding issue #71 modify Helper.fs to give an error message that is consistent with those from "__" fields.