### PR TITLE
Update Dockerfile to point at .Net Core 2 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1
 WORKDIR /koans
 CMD ["bash", "docker-meditate.sh"]
 


### PR DESCRIPTION
Fix Docker failing due to .Net Core 3.0 incompatibility.