### PR TITLE
.NET core 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 [Oo]bj/
 *.suo
 packages/
+.ionide/
+.idea/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,11 +5,22 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": ".NET Core Launch Koans tests (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/FSharpKoans.Test/bin/Debug/netcoreapp3.0/FSharpKoans.Test.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            "console": "internalConsole"
+        },
+        {
             "name": "Launch Koans (.Net Core, Console)",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceRoot}/FSharpKoans/bin/Debug/netcoreapp2.0/FSharpKoans.dll",
+            "program": "${workspaceRoot}/FSharpKoans/bin/Debug/netcoreapp3.0/FSharpKoans.dll",
             "args": [],
             "cwd": "${workspaceRoot}",
             "stopAtEntry": false,

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.1
+FROM mcr.microsoft.com/dotnet/core/sdk:3.0
 WORKDIR /koans
 CMD ["bash", "docker-meditate.sh"]
 

--- a/FSharpKoans.Core/KoanContainer.fs
+++ b/FSharpKoans.Core/KoanContainer.fs
@@ -1,7 +1,6 @@
 ﻿module FSharpKoans.Core.KoanContainer
 
 open System
-open System.IO
 open System.Reflection
 
 let hasKoanAttribute (info:MethodInfo) =

--- a/FSharpKoans.Test/FSharpKoans.Test.fsproj
+++ b/FSharpKoans.Test/FSharpKoans.Test.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <Name>FSharpKoans.Test</Name>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
@@ -11,9 +11,9 @@
     <Compile Include="GettingTheWholeOutput.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.SDK" Version="16.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.SDK" Version="16.3.0" />
     <PackageReference Include="NUnit" Version="3.8.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FSharpKoans.Core\FSharpKoans.Core.fsproj" />

--- a/FSharpKoans.Test/FindingKoans.fs
+++ b/FSharpKoans.Test/FindingKoans.fs
@@ -5,8 +5,6 @@ open FSharpKoans.Core.KoanContainer
 
 open NUnit.Framework
 
-open System.IO
-    
 type TestContainer() =
     [<Koan>]
     static member Koan1 () =

--- a/FSharpKoans/AboutUnit.fs
+++ b/FSharpKoans/AboutUnit.fs
@@ -1,6 +1,6 @@
 ﻿namespace FSharpKoans
+
 open FSharpKoans.Core
-open Microsoft.FSharp.Reflection
 
 //---------------------------------------------------------------
 // About Unit

--- a/FSharpKoans/FSharpKoans.fsproj
+++ b/FSharpKoans/FSharpKoans.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <Name>FSharpKoans</Name>
   </PropertyGroup>
   <ItemGroup>

--- a/FSharpKoans/PathToEnlightenment.fs
+++ b/FSharpKoans/PathToEnlightenment.fs
@@ -1,5 +1,4 @@
-﻿open FSharpKoans
-open FSharpKoans.Core
+﻿open FSharpKoans.Core
 
 let runner = KoanRunner()
 let result = runner.ExecuteKoans()


### PR DESCRIPTION
- changed projects target to .NET core 3.0
- removed unused `open`s
- updates libs, except NUnit. Change from `3.8.1` to `3.12.0` breaks 4 of 8 tests. Needs more investigation