### PR TITLE
Adding support for .Net Core 3

### DIFF
--- a/FSharpKoans.Core/FSharpKoans.Core.fsproj
+++ b/FSharpKoans.Core/FSharpKoans.Core.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <OutputType>Library</OutputType>
     <Name>FSharpKoans.Core</Name>
   </PropertyGroup>

--- a/FSharpKoans.Test/FSharpKoans.Test.fsproj
+++ b/FSharpKoans.Test/FSharpKoans.Test.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
     <Name>FSharpKoans.Test</Name>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/FSharpKoans/FSharpKoans.fsproj
+++ b/FSharpKoans/FSharpKoans.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
     <Name>FSharpKoans</Name>
   </PropertyGroup>
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To launch in watch mode using docker run the following command;
 
 ### Prerequisites
 
-The F# Koans needs [.Net Core 2.0](https://www.microsoft.com/net/download/core) to be built and run,
+The F# Koans needs [.Net Core 2.0](https://www.microsoft.com/net/download/core) or [.Net Core 3.0](https://www.microsoft.com/net/download/core) to be built and run,
 make sure that you have installed it before building the project.
 
 Additionally, the project provides [Visual Studio Code](https://code.visualstudio.com/) configuration for running.
@@ -32,8 +32,8 @@ To be able to run F# projects in Visual Studio Code, the
 
 1. To build the Koans, run `dotnet build` command in the project root.
 
-2. To run the Koans, run `dotnet run -p FSharpKoans/FSharpKoans.fsproj` command in the project root
-or `dotnet run` in `FSharpKoans` project directory.
+2. To run the Koans, run `dotnet run -p FSharpKoans/FSharpKoans.fsproj --framework netcoreapp2.0` or `dotnet run -p FSharpKoans/FSharpKoans.fsproj --framework netcoreapp3.0` command in the project root
+or `dotnet run --framework netcoreapp2.0` or `dotnet run --framework netcoreapp3.0` in `FSharpKoans` project directory.
 
 ### Running the Koans in Visual Studio Code
 
@@ -43,5 +43,5 @@ and press F5 to build and launch the Koans (require some time to build the proje
 ### Using dotnet-watch
 
 You can also use [dotnet-watch](https://github.com/aspnet/Docs/blob/master/aspnetcore/tutorials/dotnet-watch.md) to have your changes reloaded automatically.
-To do so, navigate into `FSharpKoans` directory and run `dotnet watch run`.
+To do so, navigate into `FSharpKoans` directory and run `dotnet watch run --framework netcoreapp2.0` or `dotnet watch run --framework netcoreapp3.0`.
 Now, after you change the project code, it will be automatically reloaded and tests rerun.


### PR DESCRIPTION
When .Net Core 3 is the only SDK installed the project doesn't run.

I added the netcoreapp3.0 to the supported frameworks and added netstandard2.1 to the classlib.

I also updated the README.md file with the framework option.