### PR TITLE
Target netcore 3.1 (LTS), clean things up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 [Oo]bj/
 *.suo
 packages/
+.ionide/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceRoot}/FSharpKoans/bin/Debug/netcoreapp2.0/FSharpKoans.dll",
+            "program": "${workspaceRoot}/FSharpKoans/bin/Debug/netcoreapp3.1/FSharpKoans.dll",
             "args": [],
             "cwd": "${workspaceRoot}",
             "stopAtEntry": false,

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.1
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 WORKDIR /koans
 CMD ["bash", "docker-meditate.sh"]
 

--- a/FSharpKoans.Core/FSharpKoans.Core.fsproj
+++ b/FSharpKoans.Core/FSharpKoans.Core.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
     <Name>FSharpKoans.Core</Name>
   </PropertyGroup>

--- a/FSharpKoans.Core/FSharpKoans.Core.fsproj
+++ b/FSharpKoans.Core/FSharpKoans.Core.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <Name>FSharpKoans.Core</Name>
   </PropertyGroup>
@@ -12,6 +12,6 @@
     <Compile Include="KoanRunner.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.8.1"/>
+    <PackageReference Include="NUnit" Version="3.12" />
   </ItemGroup>
 </Project>

--- a/FSharpKoans.Test/FSharpKoans.Test.fsproj
+++ b/FSharpKoans.Test/FSharpKoans.Test.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Name>FSharpKoans.Test</Name>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/FSharpKoans.Test/FSharpKoans.Test.fsproj
+++ b/FSharpKoans.Test/FSharpKoans.Test.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <Name>FSharpKoans.Test</Name>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
@@ -11,9 +11,9 @@
     <Compile Include="GettingTheWholeOutput.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.SDK" Version="16.0.1" />
-    <PackageReference Include="NUnit" Version="3.8.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.SDK" Version="16.5.0" />
+    <PackageReference Include="NUnit" Version="3.12" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FSharpKoans.Core\FSharpKoans.Core.fsproj" />

--- a/FSharpKoans/FSharpKoans.fsproj
+++ b/FSharpKoans/FSharpKoans.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <Name>FSharpKoans</Name>
   </PropertyGroup>
   <ItemGroup>

--- a/FSharpKoans/FSharpKoans.fsproj
+++ b/FSharpKoans/FSharpKoans.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Name>FSharpKoans</Name>
   </PropertyGroup>
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ To launch in watch mode using docker run the following command;
 
 ### Prerequisites
 
-The F# Koans needs [.Net Core 2.0](https://www.microsoft.com/net/download/core) or [.Net Core 3.0](https://www.microsoft.com/net/download/core) to be built and run,
-make sure that you have installed it before building the project.
+The F# Koans needs [.Net Core 3.1](https://www.microsoft.com/net/download/core) to be built and run. Make sure that you have installed it before building the project. This is the long-term servicing release of .NET Core that many modern F# and .NET applications use.
 
 Additionally, the project provides [Visual Studio Code](https://code.visualstudio.com/) configuration for running.
 To be able to run F# projects in Visual Studio Code, the
@@ -32,8 +31,8 @@ To be able to run F# projects in Visual Studio Code, the
 
 1. To build the Koans, run `dotnet build` command in the project root.
 
-2. To run the Koans, run `dotnet run -p FSharpKoans/FSharpKoans.fsproj --framework netcoreapp2.0` or `dotnet run -p FSharpKoans/FSharpKoans.fsproj --framework netcoreapp3.0` command in the project root
-or `dotnet run --framework netcoreapp2.0` or `dotnet run --framework netcoreapp3.0` in `FSharpKoans` project directory.
+2. To run the Koans, run `dotnet run -p FSharpKoans/FSharpKoans.fsproj --framework netcoreapp3.1` root
+or `dotnet run --framework netcoreapp3.1` in `FSharpKoans` project directory.
 
 ### Running the Koans in Visual Studio Code
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ To be able to run F# projects in Visual Studio Code, the
 
 1. To build the Koans, run `dotnet build` command in the project root.
 
-2. To run the Koans, run `dotnet run -p FSharpKoans/FSharpKoans.fsproj --framework netcoreapp3.1` root
-or `dotnet run --framework netcoreapp3.1` in `FSharpKoans` project directory.
+2. To run the Koans, run `dotnet run -p FSharpKoans/FSharpKoans.fsproj` in the root directory or `dotnet run` in `FSharpKoans` project directory.
 
 ### Running the Koans in Visual Studio Code
 
@@ -42,5 +41,4 @@ and press F5 to build and launch the Koans (require some time to build the proje
 ### Using dotnet-watch
 
 You can also use [dotnet-watch](https://github.com/aspnet/Docs/blob/master/aspnetcore/tutorials/dotnet-watch.md) to have your changes reloaded automatically.
-To do so, navigate into `FSharpKoans` directory and run `dotnet watch run --framework netcoreapp2.0` or `dotnet watch run --framework netcoreapp3.0`.
-Now, after you change the project code, it will be automatically reloaded and tests rerun.
+To do so, navigate into `FSharpKoans` directory and run `dotnet watch run`. Now, after you change the project code, it will be automatically reloaded and tests rerun.


### PR DESCRIPTION
Hey there, I came across this and got curious about it. Looks like it was a little more complicated w.r.t .NET-isms that it needs to be. Here's what I did:

* Targets .NET Core 3.1, which is the new LTS
* Remove older, unsupported netcore target
* Simplify by not doing multi-tfm. There was no need to do this in any of the projects
* Remove `netstandard2.1` target, since none of the APIs from there were used
* Added the `.ionide/` folder to `.gitignore` so VSCode users don't accidentally check in the symbol cache it uses

