### PR TITLE
Fixed typo in function name

### DIFF
--- a/FSharpKoans/AboutOptionTypes.fs
+++ b/FSharpKoans/AboutOptionTypes.fs
@@ -66,6 +66,6 @@ module ``about option types`` =
             game.Score
             |> Option.map (fun score -> if score > 3 then "play it" else "don't play")
 
-        //HINT: look at the return type of the decide on function
+        //HINT: look at the return type of the decideOn function
         AssertEquality (decideOn chronoTrigger) __
         AssertEquality (decideOn halo) __


### PR DESCRIPTION
Thanks for creating these. Was a good intro to F#.

I found and fixed a small typo on the function name "decideOn" in the AboutOptionTypes koan