### PR TITLE
Add .gitattributes set to ignore differences in line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ignore all differences in line endings
+*        -crlf


### PR DESCRIPTION
I wanted to use Remote-WSL in VS Code and run ./docker.sh in Ubuntu, but it didn't work out of the box because when cloning the repository to windows git added CRLF line endings which didn't work in Remote-WSL. Hopefully this fixes the problem.

Another solution that might work is (I still have to test it which I will if you don't think this PR solves the problem)
```
* text=auto
*.sh text eol=lf
```