### PR TITLE
Updated two broken MSDN URLs in comments

### DIFF
--- a/FSharpKoans/AboutLists.fs
+++ b/FSharpKoans/AboutLists.fs
@@ -124,4 +124,4 @@ module ``about lists`` =
 
     (* Note: There are many other useful methods in the List module. Check them
        via intellisense in Visual Studio by typing '.' after List, or online at
-       http://msdn.microsoft.com/en-us/library/ee353738.aspx *)
+       https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/lists *)

--- a/FSharpKoans/AboutStrings.fs
+++ b/FSharpKoans/AboutStrings.fs
@@ -46,7 +46,7 @@ module ``about strings`` =
         AssertEquality message __
 
     (* NOTE: For all the %formatters that you can use with string formatting 
-             see: http://msdn.microsoft.com/en-us/library/ee370560.aspx *)
+             see: https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/plaintext-formatting *)
 
     [<Koan>]
     let CombineMultiline() =


### PR DESCRIPTION
I was testing the F# koans, and stumbled on a link to MSDN that is broken, in comments (thanks microsoft for providing cheap pull requests for beginner contributors!).

I searched and fixed another one as well.

BTW, it's my first PR to an open source repo!

This one doesn't look very risky, but... if I messed something up, please inform me!