### PR TITLE
Add .gitattributes set to have .sh files line endings LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh text eol=lf


### PR DESCRIPTION
As discussed in #97 , this PR makes sure that line endings in .sh files are kept as LF when cloning this repository in windows.

Thanks for feedback @ChrisMarinos !