### PR TITLE
Upgrade to .NET 5.0 and include Devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
     "image": "mcr.microsoft.com/vscode/devcontainers/dotnetcore:0-5.0",
     "extensions": [
         "Ionide.Ionide-fsharp",
-	    "ms-dotnettools.csharp"
+        "ms-dotnettools.csharp"
     ],
     "remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
     "image": "mcr.microsoft.com/vscode/devcontainers/dotnetcore:0-5.0",
     "extensions": [
         "Ionide.Ionide-fsharp",
-		"ms-dotnettools.csharp"
+	    "ms-dotnettools.csharp"
     ],
     "remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+    "name": "F# Koans",
+    "image": "mcr.microsoft.com/vscode/devcontainers/dotnetcore:0-5.0",
+    "extensions": [
+        "Ionide.Ionide-fsharp",
+		"ms-dotnettools.csharp"
+    ],
+    "remoteUser": "vscode"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:5.0
 WORKDIR /koans
 CMD ["bash", "docker-meditate.sh"]
 

--- a/FSharpKoans.Test/FSharpKoans.Test.fsproj
+++ b/FSharpKoans.Test/FSharpKoans.Test.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Name>FSharpKoans.Test</Name>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/FSharpKoans/FSharpKoans.fsproj
+++ b/FSharpKoans/FSharpKoans.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Name>FSharpKoans</Name>
   </PropertyGroup>
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To launch in watch mode using docker run the following command;
 
 ### Prerequisites
 
-The F# Koans needs [.Net Core 3.1](https://www.microsoft.com/net/download/core) to be built and run. Make sure that you have installed it before building the project. This is the long-term servicing release of .NET Core that many modern F# and .NET applications use.
+The F# Koans needs [.Net 5.0](https://www.microsoft.com/net/download/core) to be built and run. Make sure that you have installed it before building the project. This is the current release of .NET Core that many modern F# and .NET applications use.
 
 Additionally, the project provides [Visual Studio Code](https://code.visualstudio.com/) configuration for running.
 To be able to run F# projects in Visual Studio Code, the
@@ -37,6 +37,14 @@ To be able to run F# projects in Visual Studio Code, the
 
 1. Open the project directory in Visual Studio Code with Ionide-fharp plugin installed
 and press F5 to build and launch the Koans (require some time to build the project before launch).
+
+### Running the Koans from a Devcontainer
+
+1. Install the Remote - Containers extension in Visual Studio Code.
+
+2. Open the directory inside a Devcontainer.
+
+3. Open a terminal and start using the Koans.
 
 ### Using dotnet-watch
 


### PR DESCRIPTION
Update the koans to use .NET 5.0 and also include a devcontainer to ease getting up and running.
The latest `ionide` release requires .NET 5.0

Also change the README to reflect the changes.