### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To be able to run F# projects in Visual Studio Code, the
 
 1. To build the Koans, run `dotnet build` command in the project root.
 
-2. To run the Koans, run `dotnet run -p FSharpKoans/FSharpKoans.fsproj` in the root directory or `dotnet run` in `FSharpKoans` project directory.
+2. To run the Koans, run `dotnet run --project FSharpKoans/FSharpKoans.fsproj` in the root directory or `dotnet run` in `FSharpKoans` project directory.
 
 ### Running the Koans in Visual Studio Code
 


### PR DESCRIPTION
[NETSDK1174: -p abbreviation for --project in dotnet run is deprecated](https://docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/deprecate-p-option-dotnet-run)