### PR TITLE
Upgrade to .NET 6.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "F# Koans",
-    "image": "mcr.microsoft.com/vscode/devcontainers/dotnetcore:0-5.0",
+    "image": "mcr.microsoft.com/vscode/devcontainers/dotnet:6.0",
     "extensions": [
         "Ionide.Ionide-fsharp",
         "ms-dotnettools.csharp"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,5 @@
     "extensions": [
         "Ionide.Ionide-fsharp",
         "ms-dotnettools.csharp"
-    ],
-    "remoteUser": "vscode"
+    ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceRoot}/FSharpKoans/bin/Debug/net5.0/FSharpKoans.dll",
+            "program": "${workspaceRoot}/FSharpKoans/bin/Debug/net6.0/FSharpKoans.dll",
             "args": [],
             "cwd": "${workspaceRoot}",
             "stopAtEntry": false,

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "taskName": "build",
+            "label": "build",
             "command": "dotnet build",
             "type": "shell",
             "group": "build",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 WORKDIR /koans
 CMD ["bash", "docker-meditate.sh"]
 

--- a/FSharpKoans.Test/FSharpKoans.Test.fsproj
+++ b/FSharpKoans.Test/FSharpKoans.Test.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Name>FSharpKoans.Test</Name>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/FSharpKoans/FSharpKoans.fsproj
+++ b/FSharpKoans/FSharpKoans.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Name>FSharpKoans</Name>
   </PropertyGroup>
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To launch in watch mode using docker run the following command;
 
 ### Prerequisites
 
-The F# Koans needs [.Net 5.0](https://www.microsoft.com/net/download/core) to be built and run. Make sure that you have installed it before building the project. This is the current release of .NET Core that many modern F# and .NET applications use.
+The F# Koans needs [.NET 6.0](https://dotnet.microsoft.com/download) to be built and run. Make sure that you have installed it before building the project. This is the long-term support release of .NET that many modern F# and .NET applications use.
 
 Additionally, the project provides [Visual Studio Code](https://code.visualstudio.com/) configuration for running.
 To be able to run F# projects in Visual Studio Code, the


### PR DESCRIPTION
Upgrade projects to target net6.0, as well as Docker image and devcontainer.

This also gets Ionide working again in Codespaces as it requires .NET 6.0 now.